### PR TITLE
improve: remove unnecessary Rows in SQL tests 🪶

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Add `tags` flag to manifest command for selecting which tags to generate. (2022-08-16, @n25a, !38) 
 * Remove `app` package. (2022-08-16, @nemati21, !35)
 * Add `Join` function for generating join query with tests. (2022-09-01, @n25a, !44)
+* Remove unnecessary sqlmock row creation in sql tests. (2022-10-29, @bamdadnouri, !48)
 
 # v1.2.0 - Jun 25 2022
 

--- a/internal/assets/sqlx/test_template.go
+++ b/internal/assets/sqlx/test_template.go
@@ -53,13 +53,6 @@ func (suite *%sRepositoryTestSuite) TestInsert_Success() {
 	errFakeData := faker.FakeData(&%s)
 	require.NoError(errFakeData)
 
-	sqlmock.NewRows([]string{
-		%s
-	}).
-		AddRow(
-			%s
-		)
-
 	syntax := "INSERT INTO %s .+"
 	suite.mock.ExpectExec(syntax).
 		WithArgs(
@@ -204,13 +197,6 @@ func (suite *%sRepositoryTestSuite) TestUpdate_Success() {
 	errFakeData := faker.FakeData(&%s)
 	require.NoError(errFakeData)
 
-	sqlmock.NewRows([]string{
-		%s		
-	}).
-		AddRow(
-			%s
-		)
-
 	syntax := "UPDATE %s SET .+"
 	suite.mock.ExpectExec(syntax).
 		WithArgs(
@@ -262,13 +248,6 @@ func (suite *%sRepositoryTestSuite) TestUpdate%s_Success() {
 	var %s %s.%s
 	errFakeData := faker.FakeData(&%s)
 	require.NoError(errFakeData)
-
-	sqlmock.NewRows([]string{
-		%s
-	}).
-		AddRow(
-			%s
-		)
 
 	syntax := "UPDATE %s SET (.+) WHERE (.+)"
 	suite.mock.ExpectExec(syntax).
@@ -388,9 +367,6 @@ func (s *sqlxTest) Insert(structure *structure.Structure) (syntax string) {
 		structure.Name,
 		strcase.ToLowerCamel(structure.Name),
 
-		structure.GetDBFieldsInQuotation(),
-		structure.GetVariableFields(strcase.ToLowerCamel(structure.Name)+"."),
-
 		strcase.ToSnake(structure.Name),
 		structure.GetVariableFields(strcase.ToLowerCamel(structure.Name)+"."),
 
@@ -424,9 +400,6 @@ func (s *sqlxTest) UpdateAll(structure *structure.Structure) (syntax string) {
 		structure.PackageName,
 		structure.Name,
 		strcase.ToLowerCamel(structure.Name),
-
-		structure.GetDBFieldsInQuotation(),
-		structure.GetVariableFields(strcase.ToLowerCamel(structure.Name)+"."),
 
 		strcase.ToSnake(structure.Name),
 		structure.GetVariableFields(strcase.ToLowerCamel(structure.Name)+"."),
@@ -473,9 +446,6 @@ func (s *sqlxTest) UpdateBy(structure *structure.Structure, vars *[]structure.Up
 			structure.PackageName,
 			structure.Name,
 			strcase.ToLowerCamel(structure.Name),
-
-			structure.GetDBFieldsInQuotation(),
-			structure.GetVariableFields(strcase.ToLowerCamel(structure.Name)+"."),
 
 			strcase.ToSnake(structure.Name),
 			s.addPrefix(execContextVariables(v, structure, false), strcase.ToLowerCamel(structure.Name)+"."),


### PR DESCRIPTION
The sqlmock.NewRows returns rows that are used for test cases that we expect some rows to be returned by the sqlmock. In these 3 cases, these rows were created unnecessarily and could be removed.

Describe the solution you'd like
Remove NewRows from templates and the following variables from the parser.